### PR TITLE
Update benchmarks to work after recent changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,11 @@ _data/mnist-t10k-100.txt:
 	python3 preprocessing/mnist-binary-preprocess.py _data/dl/t10k-images-idx3-ubyte _data/dl/t10k-labels-idx1-ubyte _data/mnist-t10k-100.txt 100
 
 test-cuda: _data/mnist-train-600.txt _data/mnist-t10k-100.txt
-	mi compile --accelerate-cuda benchmarks/mnist/bm-mnist.mc
+	mi compile --accelerate benchmarks/mnist/bm-mnist.mc
 	./bm-mnist _data/mnist-train-600.txt _data/mnist-t10k-100.txt
-	mi compile --accelerate-cuda src/main.mc
+	mi compile --accelerate src/main.mc
 	./main mnist _data/mnist-train-600.txt _data/mnist-t10k-100.txt
 
 test-mnist:
-	mi compile --accelerate-cuda benchmarks/mnist/bm-mnist.mc
+	mi compile --accelerate benchmarks/mnist/bm-mnist.mc
 	stdbuf -o0 ./bm-mnist _data/mnist-train.txt _data/mnist-t10k.txt


### PR DESCRIPTION
Replaces all uses of `parallelLoop` with `loop` and uses the flag `--accelerate` instead of `--accelerate-cuda` following updates in Miking.